### PR TITLE
Styling nicht auf List-Items innerhalb eines Artikels anwenden

### DIFF
--- a/fefe.css
+++ b/fefe.css
@@ -41,7 +41,7 @@ ul {
   padding-left: 0px;
 }
 
-ul li {
+ul>li {
   font-size: 16px;
   line-height: 1.3em;
   list-style-type: none;
@@ -58,7 +58,7 @@ ul li {
           box-shadow:0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset;
 }
 
-ul li:before, ul li:after {
+ul>li:before, ul>li:after {
   content:"";
   position:absolute;
   z-index:-2;


### PR DESCRIPTION
Ich habe nur ein wiziges detail geändert, und zwar, dass List Item's innerhalb eines Artikels (welcher ja auch ein List-Item ist) so wie Artikel gestyled werden, zum Beispiel: http://blog.fefe.de/?ts=b05fb0e7
