### PR TITLE
Small responsive Update for fefe.css

### DIFF
--- a/fefe.css
+++ b/fefe.css
@@ -105,8 +105,6 @@ blockquote {
     margin: 0 auto;
   }
   h2 {
-    font-family: Georgia;
-    font-weight: normal;
     font-size: 50px;
     margin-bottom: 20px;
   }
@@ -118,22 +116,11 @@ blockquote {
   }
     
   ul>li {
-    font-size: 16px;
-    line-height: 1.4em;
-    list-style-type: none;
-    position:relative;
     margin-bottom: 15px;
     padding: 25px 25px 50px 25px;
-    background:#fff;
-    color: #444444;
-    -webkit-box-shadow:0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset;
-    -moz-box-shadow:0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset;
-    box-shadow:0 1px 4px rgba(0, 0, 0, 0.3), 0 0 40px rgba(0, 0, 0, 0.1) inset;
   }
 
   blockquote {
-    font-family: Georgia;    
-    font-style: italic;
     padding-left: 0;
     margin-left: 15px;
   }


### PR DESCRIPTION
For Screens smaller than 800px width. Smaller margins on boxes and flexible widths.

Before:
![bildschirmfoto 2015-02-18 um 17 57 53](https://cloud.githubusercontent.com/assets/867891/6252240/14651422-b799-11e4-8ab0-7cf9e19dfc28.png)

After:
![bildschirmfoto 2015-02-18 um 17 58 00](https://cloud.githubusercontent.com/assets/867891/6252246/1d6bdd80-b799-11e4-8500-dddafcd657c4.png)

