### PR TITLE
Fix for <pre> and <a> breaking the design

### DIFF
--- a/fefe.css
+++ b/fefe.css
@@ -9,6 +9,7 @@ body {
 
 a {
   color: #2e9ec9;
+  word-wrap: break-word;
 }
 
 h2 {
@@ -94,6 +95,11 @@ blockquote {
   font-style: italic;
   padding-left: 10px;
   margin-left: 20px;
+}
+
+pre {
+  font-size: 0.9em;
+  overflow-x: auto;
 }
 
 /* For Screens smaller than 800px width. Smaller margins on boxes and flexible widths */


### PR DESCRIPTION
The pre tag breaks out of the normal design if containing text is to long. I propose a slightly smaller font-size and the display of scrollable content for this case.

Long links break out of the design too. I propose word-wrapping for this case.

pre-tag before:
![bildschirmfoto 2015-03-10 um 16 06 08](https://cloud.githubusercontent.com/assets/867891/6577584/6e16d28e-c73f-11e4-867b-82c142752be6.png)

pre-tag after bigscreen:
![bildschirmfoto 2015-03-10 um 16 07 12](https://cloud.githubusercontent.com/assets/867891/6577613/91769700-c73f-11e4-9d24-1580ba6e4c46.png)

pre-tag after smallscreen (scrollable):
![bildschirmfoto 2015-03-10 um 16 07 59](https://cloud.githubusercontent.com/assets/867891/6577627/abc61270-c73f-11e4-863e-6f2ae5301ebd.png)

a before:
![bildschirmfoto 2015-03-10 um 16 08 53](https://cloud.githubusercontent.com/assets/867891/6577669/d745f276-c73f-11e4-8ab2-842ea3d7900d.png)

a after:
![bildschirmfoto 2015-03-10 um 16 09 45](https://cloud.githubusercontent.com/assets/867891/6577676/e3dcebac-c73f-11e4-8a83-fcd11c2429a9.png)
